### PR TITLE
fix package name in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
             </feature>
         </config-file>
 
-        <source-file src="src/android/Cache.java" target-dir="src/com/apache/cordova/plugin/cache" />
+        <source-file src="src/android/Cache.java" target-dir="src/org/apache/cordova/plugin/cache" />
     </platform>
 
     <!-- ios -->


### PR DESCRIPTION
it seem to me (but I m a newbie for Cordova plugin implementation), that the target package name should match the java class package name.

it also seem, that the more used package name for cordova plugins is **org**.apache.cordova.plugin....